### PR TITLE
Adding appId to prepare for ACAP signing

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,6 +3,7 @@
     "acapPackageConf": {
         "setup": {
             "friendlyName": "Docker Daemon with Compose",
+            "appId": "414150",
             "appName": "dockerdwrapperwithcompose",
             "vendor": "Axis Communications",
             "embeddedSdkVersion": "3.0",


### PR DESCRIPTION
### Describe your changes

AppId is required in order to sign an ACAP in ACAP Portal

