### PR TITLE
Fix build for Docker v 20.10.9

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         arch: ["armv7hf", "aarch64"]
     outputs:

--- a/0001-change-debian-stretch-repositories.patch
+++ b/0001-change-debian-stretch-repositories.patch
@@ -1,0 +1,47 @@
+From 1d5dcb1ea1fd4090f71ac2df396e3081c8b4c1f2 Mon Sep 17 00:00:00 2001
+From: Madelen Andersson <madelan@axis.com>
+Date: Tue, 13 Jun 2023 13:13:16 +0200
+Subject: [PATCH] change debian stretch repositories
+
+Change-Id: I28c3f636f6d85bf36dd536b57dbdba288bf49e4c
+---
+ Dockerfile | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/Dockerfile b/Dockerfile
+index f269457eff..b30f238940 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -14,8 +14,9 @@ ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
+ FROM ${GOLANG_IMAGE} AS base
+ RUN echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+ ARG APT_MIRROR
+-RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
+- && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
++RUN echo 'deb http://archive.debian.org/debian/ stretch main contrib non-free' > /etc/apt/sources.list \
++ && echo 'deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free' >> /etc/apt/sources.list \
++ && echo 'deb http://archive.debian.org/debian-security stretch/updates main contrib non-free' >> /etc/apt/sources.list
+ ENV GO111MODULE=off
+ 
+ FROM base AS criu
+@@ -122,7 +123,7 @@ ARG DEBIAN_FRONTEND
+ RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
+ RUN --mount=type=cache,sharing=locked,id=moby-cross-false-aptlib,target=/var/lib/apt \
+     --mount=type=cache,sharing=locked,id=moby-cross-false-aptcache,target=/var/cache/apt \
+-        apt-get update && apt-get install -y --no-install-recommends \
++        apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
+             binutils-mingw-w64 \
+             g++-mingw-w64-x86-64 \
+             libapparmor-dev \
+@@ -141,7 +142,7 @@ ARG DEBIAN_FRONTEND
+ RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
+ RUN --mount=type=cache,sharing=locked,id=moby-cross-true-aptlib,target=/var/lib/apt \
+     --mount=type=cache,sharing=locked,id=moby-cross-true-aptcache,target=/var/cache/apt \
+-        apt-get update && apt-get install -y --no-install-recommends \
++        apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
+             libapparmor-dev:arm64 \
+             libapparmor-dev:armel \
+             libapparmor-dev:armhf \
+-- 
+2.25.1
+

--- a/Dockerfile.dockerd
+++ b/Dockerfile.dockerd
@@ -17,6 +17,7 @@ COPY Makefile.dockerd .
 COPY DOCKERVERSION .
 COPY 0001-Use-stretch-as-base-to-work-on-ARTPEC-6-7.patch .
 COPY 0001-Set-docker-proxy-via-build-arg.patch .
+COPY 0001-change-debian-stretch-repositories.patch .
 
 # Install the packages we use
 RUN <<EOF

--- a/Makefile.dockerd
+++ b/Makefile.dockerd
@@ -14,6 +14,7 @@ moby-$(DOCKERVERSION):
 	curl -L https://github.com/moby/moby/archive/refs/tags/v$(DOCKERVERSION).tar.gz | tar xz && \
 	patch -d moby-$(DOCKERVERSION) < 0001-Use-stretch-as-base-to-work-on-ARTPEC-6-7.patch
 	patch -d moby-$(DOCKERVERSION) < 0001-Set-docker-proxy-via-build-arg.patch
+	patch -d moby-$(DOCKERVERSION) < 0001-change-debian-stretch-repositories.patch
 
 moby-$(DOCKERVERSION)/bundles/cross/$(DOCKER_CROSSPLATFORMS)/dockerd: moby-$(DOCKERVERSION)
 	make -C moby-$(DOCKERVERSION) DOCKER_CROSSPLATFORMS=$(DOCKER_CROSSPLATFORMS) cross

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ case "${1:-}" in
 esac
 
 dockerdtag=dockerd:1.0
-imagetag=imagetag=${2:-docker-acap-with-compose:1.0}
+imagetag=${2:-docker-acap-with-compose:1.0}
 dockerdname=dockerd_name
 
 # First we build and copy out dockerd

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 case "$1" in
     armv7hf|aarch64)
        ;;
@@ -19,6 +19,7 @@ docker buildx build --build-arg ACAPARCH="$1" \
              --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
              --tag $dockerdtag \
              --no-cache \
+             --progress=plain \
              --file Dockerfile.dockerd .
 
 docker run -v /var/run/docker.sock:/var/run/docker.sock \
@@ -38,6 +39,7 @@ docker buildx build --build-arg ACAPARCH="$1" \
              --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
              --file Dockerfile.acap \
              --no-cache \
+             --progress=plain \
              --tag "$imagetag" . 
 
 docker cp "$(docker create "$imagetag")":/opt/app/ ./build-"$1"

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,16 @@
 #!/bin/sh -e
-case "$1" in
+case "${1:-}" in
     armv7hf|aarch64)
        ;;
     *)
        # error
-       echo "Invalid argument '$1', valid arguments are armv7hf or aarch64"
+       echo "Invalid argument '${1:-}', valid arguments are armv7hf or aarch64"
        exit 1
        ;;
 esac
 
 dockerdtag=dockerd:1.0
-imagetag="${2:-docker-acap-with-compose:1.0}"
+imagetag=${2:--docker-acap-with-compose:1.0}
 dockerdname=dockerd_name
 
 # First we build and copy out dockerd
@@ -19,7 +19,6 @@ docker buildx build --build-arg ACAPARCH="$1" \
              --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
              --tag $dockerdtag \
              --no-cache \
-             --progress=plain \
              --file Dockerfile.dockerd .
 
 docker run -v /var/run/docker.sock:/var/run/docker.sock \
@@ -39,7 +38,6 @@ docker buildx build --build-arg ACAPARCH="$1" \
              --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
              --file Dockerfile.acap \
              --no-cache \
-             --progress=plain \
              --tag "$imagetag" . 
 
 docker cp "$(docker create "$imagetag")":/opt/app/ ./build-"$1"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ case "${1:-}" in
 esac
 
 dockerdtag=dockerd:1.0
-imagetag=${2:--docker-acap-with-compose:1.0}
+imagetag=imagetag=${2:-docker-acap-with-compose:1.0}
 dockerdname=dockerd_name
 
 # First we build and copy out dockerd


### PR DESCRIPTION
Fixes issue with package not building when using Docker version 20.10.9 as base. Main issue was that the Debian Stretch repos for updates/security has moved to archive. Since Stretch has reached EOL there is also an issue with some packages no longer being authorized. Uses same fix as [docker-acap PR#98](https://github.com/AxisCommunications/docker-acap/pull/98)

A second [PR#49](https://github.com/AxisCommunications/docker-compose-acap/pull/49) will bump Docker version but I suggest we merge this first to have a buildable (at least for now) history.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
