### PR TITLE
Remove hooks for DockerHub

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/metadata-action
         with:
           suffix: -${{ matrix.arch }}
-          repository: ${{ vars.REPOSITORY_DOCKER_HUB  }}
+          repository: 'docker-compose-acap'
           get_version: 'true'
       - name: Update manifest file
         if: ( github.ref_type == 'tag')
@@ -139,7 +139,7 @@ jobs:
             }
 
   # Uploads the signed eap files from artifacts to the pre-release.
-  # This job runs if the create_prerelease job 
+  # This job runs if the create_prerelease job
   download-and-upload-artifacts:
     if: (github.ref_type == 'tag')
     permissions:

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,0 @@
-#!/bin/bash
-# shellcheck disable=SC2001
-# Extracts the architecture as the part of the image tag after '-'
-AXIS_ARCH=$(echo "$DOCKER_TAG" | sed 's/.*-\(.*\)/\1/')
-./build.sh "$AXIS_ARCH" "$IMAGE_NAME"


### PR DESCRIPTION
Retire workflow for images published to DockerHub. Signed eap-files will be uploaded to GitHub instead, together with releases.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #46

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
