### PR TITLE
Added support for secondary groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,6 @@ of the groups need to be used. At the moment of writing this the mappings are
 | ------------ | ------------------ |
 | datacache    | "1"                |
 | sdk          | "2"                |
-| sdk          | "2"                |
 | storage      | "3"                |
 | vdo          | "4"                |
 | optics       | "5"                |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ device. In addition it bundles the docker CLI and the docker Compose CLI.
 * [Contributing](#contributing)
 * [License](#license)
 
-
 ## Overview
 
 The Docker Compose ACAP provides the means to run a Docker daemon on an Axis device, thereby
@@ -47,7 +46,7 @@ will run in rootless mode, i.e. the user owning the daemon process will not be r
 and in extension, the containers will not have root access to the host system.
 See [Rootless Mode][docker-rootless-mode] on Docker.com for details. That page also
 contains known limitations when running rootless Docker.
-In addition the [docker CLI[dockerCLI]] and [docker compose CLI][dockerComposeCLI]
+In addition the [docker CLI][dockerCLI] and [docker compose CLI][dockerComposeCLI]
 are included in the application, thereby providing the means to access these e.g.
 from a separate ACAP application running on the device.
 

--- a/README.md
+++ b/README.md
@@ -340,10 +340,10 @@ file. When running a container a user called `root`, (uid 0), belonging to group
 will be the default user inside the container. It will be mapped to the non-root user on
 the device, and the group will be mapped to the non-root users primary group.
 In order to get access inside the container to resources on the device that are group owned by any
-of the non-root users secondary groups these need to be added for the container user.
+of the non-root users secondary groups, these need to be added for the container user.
 This can be done by using `group_add` in a docker-compose.yaml (`--group-add` if using Docker cli).
-Unfortunately, adding the names of the secondary groups are not supported, instead the *mapped* ids
-of the groups need to be used. At the moment of writing this the mappings are
+Unfortunately, adding the name of a secondary group is not supported. Instead the *mapped* id
+of the group need to be used. At the moment of writing this the mappings are:
 
 | device group | container group id |
 | ------------ | ------------------ |

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -4,6 +4,8 @@
         "linux": {
             "user": {
                 "groups": [
+                    "datacache",
+                    "optics",
                     "sdk",
                     "storage",
                     "vdo"
@@ -20,7 +22,7 @@
             "embeddedSdkVersion": "3.0",
             "vendorUrl": "https://www.axis.com",
             "runMode": "once",
-            "version": "2.0.0-preview"
+            "version": "2.0.1-preview"
         },
         "installation": {
             "postInstallScript": "postinstallscript.sh"

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -9,10 +9,10 @@ fi
 _appname=dockerdwrapperwithcompose
 _appdirectory=/usr/local/packages/$_appname
 _uname="$(stat -c '%U' "$_appdirectory")"
-_uid="$(id "$_uname" -u)"
-_gid="$(id "$_uname" -g)"
-_gname="$(id "$_uname" -gn)"
-_grpsid="$(id "$_uname" -G)"
+_uid="$(id "$_uname" -u)"       # user id
+_gid="$(id "$_uname" -g)"       # user group id
+_gname="$(id "$_uname" -gn)"    # user group name
+_all_gids="$(id "$_uname" -G)"  # user sub-group ids
 
 # If the device supports cgroups v2 we need to start the user.service
 if [ ! -d /sys/fs/cgroup/unified ]; then
@@ -29,11 +29,11 @@ Wants=acap-user@$_uid.service" >> /etc/systemd/system/sdkdockerdwrapperwithcompo
 
 fi
 
-# Create mapping for subuid and subgid - both shall use user id!
+# Create mapping for subuid and subgid - both shall use user id as first value!
 echo "$_uid:100000:65536" >> /etc/subuid
-for gid in $_grpsid ; do
-    if [ "$gid" -ne "$_gid" ]; then
-        echo "$_uid:$gid:1" >> /etc/subgid
+for sub_group_id in $_all_gids ; do
+    if [ "$sub_group_id" -ne "$_gid" ]; then
+        echo "$_uid:$sub_group_id:1" >> /etc/subgid
     fi
 done
 echo "$_uid:100000:65536" >> /etc/subgid

--- a/app/postinstallscript.sh
+++ b/app/postinstallscript.sh
@@ -10,7 +10,9 @@ _appname=dockerdwrapperwithcompose
 _appdirectory=/usr/local/packages/$_appname
 _uname="$(stat -c '%U' "$_appdirectory")"
 _uid="$(id "$_uname" -u)"
+_gid="$(id "$_uname" -g)"
 _gname="$(id "$_uname" -gn)"
+_grpsid="$(id "$_uname" -G)"
 
 # If the device supports cgroups v2 we need to start the user.service
 if [ ! -d /sys/fs/cgroup/unified ]; then
@@ -27,9 +29,14 @@ Wants=acap-user@$_uid.service" >> /etc/systemd/system/sdkdockerdwrapperwithcompo
 
 fi
 
-# Create mapping for subuid and subgid - both shall use user name!
-echo "$_uname:100000:65536" > /etc/subuid
-echo "$_uname:100000:65536" > /etc/subgid
+# Create mapping for subuid and subgid - both shall use user id!
+echo "$_uid:100000:65536" >> /etc/subuid
+for gid in $_grpsid ; do
+    if [ "$gid" -ne "$_gid" ]; then
+        echo "$_uid:$gid:1" >> /etc/subgid
+    fi
+done
+echo "$_uid:100000:65536" >> /etc/subgid
 
 # Let root own these two utilities and make the setuid
 chown root:root newuidmap

--- a/app/preuninstallscript.sh
+++ b/app/preuninstallscript.sh
@@ -30,5 +30,5 @@ rm -Rf /etc/systemd/system/acap-user-runtime-dir@.service
 rm -Rf /etc/systemd/system/acap-user@.service
 
 # Remove the subuid/subgid mappings
-sed -i "/$_uname:100000:65536/d" /etc/subuid
-sed -i "/$_uname:100000:65536/d" /etc/subgid
+sed -i "/$_uid/d" /etc/subuid
+sed -i "/$_uid/d" /etc/subgid


### PR DESCRIPTION
NB! If a container needs sub-group access it has to use the group-add flag.

### Describe your changes

Adding mapping for secondary groups to /etc/subgid. This makes it possible to add secondary groups to containers and have them mapped to real groups on the device.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
