### PR TITLE
Added workflow for cherry-picking

### DIFF
--- a/.github/workflows/cherry-picker.yml
+++ b/.github/workflows/cherry-picker.yml
@@ -1,0 +1,47 @@
+# yamllint disable rule:line-length
+---
+name: Cherry-pick and create PR
+
+# Workflow action that cherry-picks from the main branch on docker-acap
+# and creates a PR.
+
+on: workflow_dispatch
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: create pr of cherry-pick
+        run: |
+          pr_branch="cherrybot-${RANDOM}"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          git switch -c $pr_branch
+          git remote add other $OTHER_REPO_FULL.git -f --no-tags -t main -m main
+
+          commit_hash="$(git rev-parse refs/remotes/other/HEAD)"
+          git cherry-pick $commit_hash --strategy-option theirs
+
+          remote_pr_id=$(gawk 'match($0, /\(#([0-9]+)\)$/, ary) {print ary[1]}' <<< $(git show -s --format=%s))
+          trimmed_commit_msg="$(sed -E '1 s/ \(#[0-9]+\)$//' <<< $(git show -s --format=%B))"
+          git commit --amend -m "$trimmed_commit_msg" 
+
+          title_txt="$(git show -s --format=%s)"
+          echo "title text is $title_txt"
+
+          remote_pr_body="$(gh pr view $remote_pr_id --repo $OTHER_REPO_FULL.git --json body --jq '.body')"  
+          body_text="This is an automatic cherry-pick of [$commit_hash]($OTHER_REPO_FULL/commit/$commit_hash)
+
+          The original PR was [#$remote_pr_id]($OTHER_REPO_FULL/pull/$remote_pr_id) with message:
+
+          $remote_pr_body"
+          echo "body text is $body_text"
+
+          git push --set-upstream origin $pr_branch
+          gh pr create --title "$title_txt" --body "$body_text" --base main --repo $THIS_REPO
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THIS_REPO: "AxisCommunications/docker-compose-acap"
+          OTHER_REPO_FULL: "https://github.com/AxisCommunications/docker-acap"


### PR DESCRIPTION
### Describe your changes

Workflow that creates PR by making a cherry-pick from main on [docker-acap](https://github.com/AxisCommunications/docker-acap). The action is triggered by `workflow_dispatch` and it will be accompanied by a new workflow action in docker-acap that sends a workflow_dispatch event when an PR is merged to main


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
