### PR TITLE
Fix readme release links pointing to the wrong repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,8 +495,8 @@ Take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 <!-- Links to external references -->
 <!-- markdownlint-disable MD034 -->
-[1.5.0-release]: https://github.com/AxisCommunications/docker-acap/releases/tag/1.5.0
-[2.0.0-release]: https://github.com/AxisCommunications/docker-acap/releases/tag/2.0.0
+[1.5.0-release]: https://github.com/AxisCommunications/docker-compose-acap/releases/tag/1.5.0
+[2.0.0-release]: https://github.com/AxisCommunications/docker-compose-acap/releases/tag/2.0.0
 [acap-native-container-example]: https://github.com/AxisCommunications/acap-native-sdk-examples/tree/main/container-example
 [buildx]: https://docs.docker.com/build/install-buildx/
 [devices]: https://axiscommunications.github.io/acap-documentation/docs/axis-devices-and-compatibility#sdk-and-device-compatibility
@@ -507,7 +507,7 @@ Take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 [docker-hello-world]: https://hub.docker.com/_/hello-world
 [docker-rootless-mode]: https://docs.docker.com/engine/security/rootless/
 [docker-proxy]: https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
-[latest-release]: https://github.com/AxisCommunications/docker-acap/releases/latest
+[latest-release]: https://github.com/AxisCommunications/docker-compose-acap/releases/latest
 [object-detector-python]: https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-python
 [product-selector]: https://www.axis.com/support/tools/product-selector
 [product-selector-container]: https://www.axis.com/support/tools/product-selector/shared/%5B%7B%22index%22%3A%5B4%2C2%5D%2C%22value%22%3A%22Yes%22%7D%5D


### PR DESCRIPTION
### Describe your changes

I accidentally installed the wrong acap before because the links points to a different repository.


### Checklist before requesting a review

- [X] I have performed a self-review of my own documentation.
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [X] I have made changes to the documentation
